### PR TITLE
brainfuck.js の修正

### DIFF
--- a/study_algorithm/brainfuck.js
+++ b/study_algorithm/brainfuck.js
@@ -2,22 +2,14 @@ function main(input){
     input = input.split("");
     let output = "";
     let ptr = 0;
-    let data = [0, null];
+    let data = [0];
     let bracketIndex = [];
-    let skipCounter = 0
 
     for(let i = 0;i < input.length;i++){
-        if(skipCounter != 0 && /[^\[\]]/.test(input[i])){
-            ptr++;
-            continue;
-        }
         switch(input[i]){
             case ">":
                 ptr++;
-                if(data[ptr] == null){
-                    data[ptr] = 0;
-                    data.push(null);
-                }
+                if(data.length-1 <= i) data.push(0);
                 break;
             case "<":
                 ptr--;
@@ -32,22 +24,11 @@ function main(input){
                 output += String.fromCharCode(data[ptr]);
                 break;
             case "[":
-                if(data[ptr] != 0){
-                    bracketIndex.push(i);
-                }else{
-                    skipCounter++;
-                }
+                bracketIndex.push(i);
                 break;
             case "]":
-                if(data[ptr] != 0){
-                    i = bracketIndex.pop()-1;
-                }else{
-                    if(skipCounter == 0){
-                        bracketIndex.pop();
-                    }else{
-                        skipCounter--;
-                    }
-                }
+                if(data[ptr] == 0) bracketIndex.pop();
+                else i = bracketIndex[bracketIndex.length-1];
                 break;
         }
     }


### PR DESCRIPTION
- `skipCounter` は `bracketIndex` の配列長で代用できそうなので消しました
- `]` に来たときに 「 `[` のひとつ後ろ」 に移動するようにしました
- `data` の長さが足りないときの処理を簡素にしました
- 可読性のために条件分岐を省略形で書きました

これで動くと思います